### PR TITLE
[Feature] Oauth2 인증 및 Spring Security 인가 설정

### DIFF
--- a/blog-api/build.gradle
+++ b/blog-api/build.gradle
@@ -19,9 +19,14 @@ dependencies {
 
     // spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
-
-    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     // Spring Rest Docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
@@ -81,7 +86,6 @@ tasks.register('copyConfig', Copy) {
     include "application*.yml"
     into 'src/main/resources'
 }
-
 
 
 processResources.dependsOn('copyConfig')

--- a/blog-api/src/main/java/com/ywoosang/tech/config/CorsMvcConfig.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/config/CorsMvcConfig.java
@@ -1,0 +1,27 @@
+package com.ywoosang.tech.config;
+
+// 컨트롤러단에서 보내주는 클래스를 받을 수 있도록
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Value("${frontend.base-url}")
+    private String frontendBaseUrl;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry
+                .addMapping("/**")
+                .exposedHeaders("Set-Cookie", "Authorization")
+                .allowedOrigins(frontendBaseUrl)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // OPTIONS 추가
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/config/SecurityConfig.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/config/SecurityConfig.java
@@ -1,0 +1,107 @@
+package com.ywoosang.tech.config;
+
+import com.ywoosang.tech.domain.auth.jwt.JwtAuthFilter;
+import com.ywoosang.tech.domain.auth.oauth2.CustomSuccessHandler;
+import com.ywoosang.tech.domain.auth.oauth2.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@EnableMethodSecurity // 찾아보기
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomSuccessHandler customSuccessHandler;
+    private final JwtAuthFilter jwtAuthFilter;
+
+    @Value("${frontend.base-url}")
+    private String frontendBaseURL;
+
+    // 정적 파일은 필터들 타지 않도록
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().requestMatchers(
+                new AntPathRequestMatcher("/public/**"),
+                new AntPathRequestMatcher("/favicon.ico"),
+                new AntPathRequestMatcher("/css/**")
+        );
+    }
+
+    // cors 구성
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        return request -> {
+            CorsConfiguration config = new CorsConfiguration();
+            config.setAllowedOrigins(Collections.singletonList(frontendBaseURL));
+            config.setAllowedMethods(Collections.singletonList("*"));
+            config.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));
+            config.setAllowCredentials(true);
+            config.setMaxAge(3600L);
+            return config;
+        };
+    }
+
+    // oauth 인증용 필터체인
+    @Bean
+    public SecurityFilterChain oauth2SecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatchers(auth -> auth
+                        .requestMatchers(
+                                "/oauth2/authorization/**",
+                                "/login/oauth2/code/**"
+                        )
+                )
+                .cors(corsCustomizer -> corsCustomizer.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+
+    // jwt 인가용 필터체인
+    @Bean
+    public SecurityFilterChain jwtSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatchers(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/**"
+                        )
+                )
+                .cors(corsCustomizer -> corsCustomizer.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterAfter(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .authorizeHttpRequests((auth) -> auth
+                        // 관리자 권한이 필요
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        // 이외 요청 모두 jwt 필터를 타도록 설정 -> 로그인하지 않았어도 GUEST 로 Context 저장
+                        .anyRequest().authenticated())
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}
+

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtAuthFilter.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtAuthFilter.java
@@ -1,0 +1,48 @@
+package com.ywoosang.tech.domain.auth.jwt;
+
+
+import com.ywoosang.tech.domain.auth.oauth2.dto.CustomOAuth2User;
+import com.ywoosang.tech.domain.auth.oauth2.dto.OAuth2UserDTO;
+import com.ywoosang.tech.domains.member.entity.Member;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = jwtService.resolveToken(request);
+        OAuth2UserDTO oauth2UserDTO;
+        // 로그인한 사용자
+        if(accessToken != null && !jwtService.isExpired(accessToken)) {
+            Member member = jwtService.getMemberFromToken(accessToken);
+            oauth2UserDTO = OAuth2UserDTO.from(member);
+        // 로그인하지 않은 사용자
+        } else {
+            // authenticated() 를 거쳐야 하니까 ContextHolder 에 GUEST 로 집어넣음
+            oauth2UserDTO = OAuth2UserDTO.from(null);
+        }
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(oauth2UserDTO);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                customOAuth2User,
+                null,
+                customOAuth2User.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtService.java
@@ -1,0 +1,104 @@
+package com.ywoosang.tech.domain.auth.jwt;
+
+import com.ywoosang.tech.code.AuthErrorCode;
+import com.ywoosang.tech.domains.member.entity.Member;
+import com.ywoosang.tech.domains.member.repository.MemberRepository;
+import com.ywoosang.tech.enums.MemberRole;
+import com.ywoosang.tech.exception.CustomException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+    MemberRepository memberRepository;
+
+    @Value("${jwt.access.secret}")
+    private String accessTokenSecret;
+
+    @Value("${jwt.access.expires-in}")
+    private int accessTokenExpiresIn;
+
+    @Value("${jwt.refresh.secret}")
+    private String refreshTokenSecret;
+
+    @Value("${jwt.refresh.expires-in}")
+    private int refreshExpiresIn;
+
+    private SecretKey accessTokenSecretKey;
+    private SecretKey refreshTokenSecretKey;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @PostConstruct
+    public void initialize() {
+        System.out.println("accessTokenSecret = " + accessTokenSecret);
+        System.out.println("refreshTokenSecret = " + refreshTokenSecret);
+
+        accessTokenSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(accessTokenSecret));
+        refreshTokenSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(refreshTokenSecret));
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)){
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+    public String createAccessToken(String email, MemberRole role) {
+        return Jwts.builder()
+                .claim("email", email)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpiresIn))
+                .signWith(accessTokenSecretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(String email) {
+        return null;
+    }
+
+
+    public boolean isExpired(String token) {
+        try {
+            return Jwts.parser().verifyWith(accessTokenSecretKey).build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getExpiration()
+                    .before(new Date());
+        } catch (JwtException e) {
+            log.warn("Invalid JWT token: {}", e.getMessage());
+            throw new CustomException(AuthErrorCode.AUTHENTICATION_FAILED);
+        }
+    }
+
+    public Member getMemberFromToken(String token) {
+        String email = getEmailFromToken(token);
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.AUTHENTICATION_FAILED));
+    }
+
+    private String getEmailFromToken(String token) {
+        return Jwts.parser().verifyWith(accessTokenSecretKey).build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role",String.class);
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/CustomSuccessHandler.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/CustomSuccessHandler.java
@@ -1,0 +1,40 @@
+package com.ywoosang.tech.domain.auth.oauth2;
+
+import com.ywoosang.tech.domain.auth.oauth2.dto.CustomOAuth2User;
+import com.ywoosang.tech.domain.auth.jwt.JwtService;
+import com.ywoosang.tech.domain.auth.oauth2.utils.CookieUtil;
+import com.ywoosang.tech.enums.MemberRole;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtService jwtService;
+    private final CookieUtil cookieUtil;
+
+    @Value("${frontend.auth-redirect-url}")
+    private String authRedirectUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+        String email = customUserDetails.getName();
+        MemberRole role = customUserDetails.getRole();
+        // jwt 생성
+        String accessToken = jwtService.createAccessToken(email, role);
+        // String refreshToken = jwtService.createRefreshToken(email);
+        response.addCookie(cookieUtil.createAccessTokenCookie(accessToken));
+        response.sendRedirect(authRedirectUrl);
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/CustomOAuth2User.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/CustomOAuth2User.java
@@ -1,0 +1,58 @@
+package com.ywoosang.tech.domain.auth.oauth2.dto;
+
+import com.ywoosang.tech.enums.MemberRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+    private final OAuth2UserDTO oauth2UserDTO;
+
+    @Override
+    public <A> A getAttribute(String name) {
+        return (A) getAttributes().get(name);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Map.of(
+                "email", oauth2UserDTO.getEmail(),
+                "nickname", oauth2UserDTO.getNickname(),
+                "profileImage", oauth2UserDTO.getProfileImage()
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add((GrantedAuthority) () -> oauth2UserDTO.getRole().getRoleName());
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return oauth2UserDTO.getEmail();
+    }
+
+    // getAttribute 로 가져올 수 있지만 명시적으로 가져오기 위해 추가
+    public MemberRole getRole() {
+        return oauth2UserDTO.getRole();
+    }
+
+    public String getNickname() {
+        return oauth2UserDTO.getNickname();
+    }
+
+    public String getEmail() {
+        return oauth2UserDTO.getEmail();
+    }
+
+    public String getProfileImage() {
+        return oauth2UserDTO.getProfileImage();
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/OAuth2Attributes.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/OAuth2Attributes.java
@@ -1,0 +1,59 @@
+package com.ywoosang.tech.domain.auth.oauth2.dto;
+
+import com.ywoosang.tech.domain.auth.oauth2.enums.SocialType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuth2Attributes {
+    private final Map<String, Object> attributes;
+    private final String email;
+    private final String nickname;
+    private final String profileImage;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private OAuth2Attributes(Map<String, Object> attributes, String email, String nickname, String profileImage) {
+        this.attributes = attributes;
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
+    public static OAuth2Attributes of(SocialType socialType, Map<String, Object> attributes) {
+        return switch (socialType) {
+            case  KAKAO -> ofKakao(attributes);
+            case  GOOGLE -> ofGoogle(attributes);
+            case  NAVER -> ofNaver(attributes);
+        };
+    }
+
+    private static OAuth2Attributes ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, String> profile = (Map<String, String>) kakaoAccount.get("profile");
+        return OAuth2Attributes.builder().
+                email(String.valueOf(kakaoAccount.get("email")))
+                .nickname(profile.get("nickname"))
+                .profileImage(profile.get("profile_image_url"))
+                .build();
+    }
+
+    private static OAuth2Attributes ofGoogle(Map<String, Object> attributes) {
+        return OAuth2Attributes.builder()
+                .email(String.valueOf(attributes.get("email")))
+                .nickname(String.valueOf(attributes.get("name")))
+                .profileImage(String.valueOf(attributes.get("picture")))
+                .build();
+    }
+
+    private static OAuth2Attributes ofNaver(Map<String, Object> attributes) {
+        Map<String,String> response = (Map<String, String>) attributes.get("response");
+        return OAuth2Attributes.builder()
+                .email(response.get("email"))
+                .nickname(response.get("nickname"))
+                .profileImage(response.get("profile_image"))
+                .build();
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/OAuth2UserDTO.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/OAuth2UserDTO.java
@@ -1,0 +1,36 @@
+package com.ywoosang.tech.domain.auth.oauth2.dto;
+
+import com.ywoosang.tech.domains.member.entity.Member;
+import com.ywoosang.tech.enums.MemberRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuth2UserDTO {
+    private final String nickname;
+    private final String email;
+    private final String profileImage;
+    private final MemberRole role;
+
+    @Builder
+    private OAuth2UserDTO(String nickname, String email, String profileImage, MemberRole role) {
+        this.nickname = nickname;
+        this.email = email;
+        this.profileImage = profileImage;
+        this.role = role;
+    }
+
+    public static OAuth2UserDTO from(Member member) {
+        if(member == null) {
+            return OAuth2UserDTO.builder()
+                    .role(MemberRole.GUEST)
+                    .build();
+        }
+        return OAuth2UserDTO.builder()
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .profileImage(member.getProfileImage())
+                .role(member.getRole())
+                .build();
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/enums/SocialType.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/enums/SocialType.java
@@ -1,0 +1,28 @@
+package com.ywoosang.tech.domain.auth.oauth2.enums;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+public enum SocialType {
+    KAKAO("kakao"),
+    GOOGLE("google"),
+    NAVER("naver");
+
+    private final String registrationId;
+
+    SocialType(String registrationId) {
+        this.registrationId = registrationId;
+    }
+
+    private String getRegistrationId() {
+        return registrationId;
+    }
+
+    public static SocialType from(String registrationId) {
+        for (SocialType socialType : SocialType.values()) {
+            if(socialType.getRegistrationId().equals(registrationId)) {
+                return socialType;
+            }
+        }
+        throw new OAuth2AuthenticationException("OAuth2 제공자가 올바르지 않습니다. registrationId: %s".formatted(registrationId));
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,60 @@
+package com.ywoosang.tech.domain.auth.oauth2.service;
+
+import com.ywoosang.tech.domain.auth.oauth2.enums.SocialType;
+import com.ywoosang.tech.domain.auth.oauth2.dto.CustomOAuth2User;
+import com.ywoosang.tech.domain.auth.oauth2.dto.OAuth2Attributes;
+import com.ywoosang.tech.domain.auth.oauth2.dto.OAuth2UserDTO;
+import com.ywoosang.tech.domains.member.entity.Member;
+import com.ywoosang.tech.domains.member.repository.MemberRepository;
+import com.ywoosang.tech.enums.MemberRole;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(request);
+
+        // Oauth2 서비스명
+        String registrationId = request.getClientRegistration().getRegistrationId();
+        // 인증된 사용자 정보
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        // 소셜 로그인 종류
+        SocialType socialType = SocialType.from(registrationId);
+        // 소셜 로그인 attributes
+        OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of(socialType, attributes);
+
+        Member member = memberRepository.findByEmail(oAuth2Attributes.getEmail())
+                .orElseGet(() -> {
+                    // 사용자가 없다면 생성
+                    Member newMember = Member.builder()
+                            .nickname(oAuth2Attributes.getNickname())
+                            .email(oAuth2Attributes.getEmail())
+                            .profileImage(oAuth2Attributes.getProfileImage())
+                            .role(MemberRole.USER)
+                            .build();
+
+                    log.info("사용자 가입 이메일: {}", newMember.getEmail());
+                    return memberRepository.save(newMember);
+                });
+        log.info("사용자 로그인 이메일: {}", member.getEmail());
+        OAuth2UserDTO oauth2UserDTO = OAuth2UserDTO.from(member);
+
+        // SecurityContext 에 저장
+        return new CustomOAuth2User(oauth2UserDTO);
+    }
+
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/utils/CookieUtil.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/utils/CookieUtil.java
@@ -1,0 +1,50 @@
+package com.ywoosang.tech.domain.auth.oauth2.utils;
+
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+    @Value("${cookie.max-age}")
+    private int maxAge;
+
+    @Value("${cookie.domain}")
+    private String domain;
+
+    // 로그인 직후 로컬스토리지로 이동시키기 때문에 만료시간을 짧게 설정
+    public Cookie createTokenCookie(String cookieName, String token) {
+        Cookie cookie = new Cookie(cookieName, token);
+        cookie.setMaxAge(maxAge);
+        cookie.setPath("/");
+        cookie.setDomain(domain);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        return cookie;
+    }
+
+    public void clearTokenCookie(String cookieName, HttpServletResponse response) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setDomain(domain);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        response.addCookie(cookie);
+    }
+
+    public Cookie createAccessTokenCookie(String token) {
+        return createTokenCookie("accessToken", token);
+    }
+
+    public Cookie createRefreshTokenCookie(String token) {
+        return createTokenCookie("refreshToken", token);
+    }
+
+    public void clearAccessAndRefreshTokenCookie(HttpServletResponse response) {
+        clearTokenCookie("accessToken", response);
+        clearTokenCookie("refreshToken", response);
+    }
+}

--- a/blog-domain/src/main/java/com/ywoosang/tech/domains/member/entity/Member.java
+++ b/blog-domain/src/main/java/com/ywoosang/tech/domains/member/entity/Member.java
@@ -35,13 +35,15 @@ import java.time.LocalDateTime;
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long userId;
+    private Long memberId;
 
     @Column(nullable = false, length = 20)
     private String nickname;
 
     @Column(nullable = false, length = 255)
     private String email;
+
+    private String profileImage;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
@@ -51,10 +53,11 @@ public class Member extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public Member(Long userId, String nickname, String email, MemberRole role) {
-        this.userId = userId;
+    public Member(Long memberId, String nickname, String email, String profileImage, MemberRole role) {
+        this.memberId = memberId;
         this.nickname = nickname;
         this.email = email;
+        this.profileImage = profileImage;
         this.role = role;
     }
 

--- a/blog-domain/src/main/java/com/ywoosang/tech/domains/member/repository/MemberRepository.java
+++ b/blog-domain/src/main/java/com/ywoosang/tech/domains/member/repository/MemberRepository.java
@@ -3,7 +3,9 @@ package com.ywoosang.tech.domains.member.repository;
 import com.ywoosang.tech.domains.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
 }

--- a/blog-domain/src/main/java/com/ywoosang/tech/enums/MemberRole.java
+++ b/blog-domain/src/main/java/com/ywoosang/tech/enums/MemberRole.java
@@ -1,5 +1,14 @@
 package com.ywoosang.tech.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum MemberRole {
-    ADMIN, USER
+    ADMIN("ROLE_ADMIN"),
+    USER("ROLE_USER"),
+    GUEST("ROLE_GUEST");
+
+    private final String roleName;
 }


### PR DESCRIPTION
 ### 상세내용
- **SecurityConfig 구성**
  - Spring Security 설정을 통해 OAuth2와 JWT 기반의 인증 방식을 설정
  - `/api/v1/**` 경로에 대한 JWT 인증 필터 추가
  - 관리자 권한이 필요한 `/api/v1/admin/**` 경로 설정
  - 필터체인을 2개 구성해 인증과 인가 분리

- **Oauth2 Success 핸들러 추가**
  - OAuth2 인증 성공 시 추가 작업을 처리하는 핸들러 구현

- **JWT 의존성 추가**
  - 프로젝트에 JWT 관련 의존성 추가로 JWT 토큰 생성 및 검증 기능 준비

- **Member 엔티티에 profileImage 컬럼 추가**
  - 사용자 엔티티에 프로필 이미지를 저장할 수 있는 profileImage 컬럼 추가

- **OAuth2UserDTO 추가**
  - OAuth2 사용자 정보를 캡슐화하기 위한 DTO 추가
  - CustomOAuth2User에 사용자 정보를 넘겨주기 위해 사용

- **OAuth2Attributes 추가**
  - 소셜 로그인 타입별로 사용자 정보를 추출하기 위한 클래스 추가
  - 리소스 서버에서 가져온 정보 추출 용도

- **JWT 서비스 추가**
  - JWT 토큰 생성 및 검증을 담당하는 서비스 추가

- **CustomOAuth2UserService 클래스 추가**
  - DefaultOAuth2UserService를 상속하여 사용자 정보 로딩 및 사용자 정의 로직 구현

- **CustomOAuth2User 클래스 추가**
  - OAuth2User를 상속하는 CustomOAuth2User 클래스 추가
  - OAuth2 사용자 정보를 캡슐화

- **소셜 로그인 타입 enum 추가**
  - 소셜 로그인 타입을 관리하기 위한 enum 클래스 추가

- **이메일 기반 사용자 조회 추가**
  - 이메일을 기반으로 사용자를 조회하는 기능 추가

- **쿠키 발급을 위한 유틸클래스 추가**
  - JWT 토큰을 쿠키로 발급하기 위한 유틸리티 클래스 추가

- **CORS 설정 추가**
  - 클라이언트와 서버 간의 통신을 원활하게 하기 위한 CORS 설정 추가

- **MemberRole에 GUEST 권한 추가**
  - 로그인하지 않은 사용자를 GUEST로 SecurityContext에 넣기 위해 GUEST 권한 추가

- **Oauth2 설정 추가**
  - OAuth2 설정을 통해 클라이언트와의 인증 및 권한 부여 구성