### PR TITLE
[Feature] refresh 토큰을 이용한 accessToken 갱신로직 추가

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -14,13 +14,20 @@ jobs:
 
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:13
         ports:
           - 5432:5432
         env:
           POSTGRES_DB: ${{ secrets.PG_DB_NAME }}
           POSTGRES_USER: ${{ secrets.PG_DB_USERNAME }}
           POSTGRES_PASSWORD: ${{ secrets.PG_DB_PASSWORD }}
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        env:
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
 
     steps:
       - name: 리포지토리 checkout

--- a/blog-api/src/main/java/com/ywoosang/tech/config/RedisConfig.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/config/RedisConfig.java
@@ -22,6 +22,7 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactory() {
         // 공식문서 https://docs.spring.io/spring-data/redis/docs/current/api/org/springframework/data/redis/connection/RedisStandaloneConfiguration.html
         RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+        System.out.println("redisConfig = " + redisConfig);
         redisConfig.setHostName(redisProperties.getHost());
         redisConfig.setPort(redisProperties.getPort());
         redisConfig.setPassword(redisProperties.getPassword());

--- a/blog-api/src/main/java/com/ywoosang/tech/config/SecurityConfig.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/config/SecurityConfig.java
@@ -95,8 +95,10 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .addFilterAfter(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests((auth) -> auth
-                        // 관리자 권한이 필요
+                        // 관리자 권한이 필요힌 경로
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        // access 토큰 재발급
+                        .requestMatchers("/api/v1/auth/token/reissue").permitAll()
                         // 이외 요청 모두 jwt 필터를 타도록 설정 -> 로그인하지 않았어도 GUEST 로 Context 저장
                         .anyRequest().authenticated())
                 .sessionManagement((session) -> session

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/controller/AuthController.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/controller/AuthController.java
@@ -1,0 +1,34 @@
+package com.ywoosang.tech.domain.auth.controller;
+
+import com.ywoosang.tech.domain.auth.dto.TokenResponse;
+import com.ywoosang.tech.domain.auth.service.AuthService;
+import com.ywoosang.tech.response.ResponseFactory;
+import com.ywoosang.tech.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.antlr.v4.runtime.Token;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/v1/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/token/reissue")
+    public ResponseEntity<SuccessResponse<TokenResponse>> reissueToken(@RequestParam("token") String token) {
+        TokenResponse tokenResponse = authService.reissueToken(token);
+        return ResponseFactory.success(tokenResponse);
+    }
+
+
+
+
+
+
+
+
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/controller/AuthController.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/controller/AuthController.java
@@ -5,7 +5,6 @@ import com.ywoosang.tech.domain.auth.service.AuthService;
 import com.ywoosang.tech.response.ResponseFactory;
 import com.ywoosang.tech.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
-import org.antlr.v4.runtime.Token;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/dto/TokenResponse.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,14 @@
+package com.ywoosang.tech.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TokenResponse {
+    String accessToken;
+
+    @Builder
+    public TokenResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtAuthFilter.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtAuthFilter.java
@@ -1,10 +1,8 @@
 package com.ywoosang.tech.domain.auth.jwt;
 
-
 import com.ywoosang.tech.domain.auth.oauth2.dto.CustomOAuth2User;
 import com.ywoosang.tech.domain.auth.oauth2.dto.OAuth2UserDTO;
 import com.ywoosang.tech.domains.member.entity.Member;
-import com.ywoosang.tech.exception.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,9 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -36,8 +32,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if(accessToken != null && !jwtService.isAccessTokenExpired(accessToken)) {
             Member member = jwtService.getMemberFromAccessToken(accessToken);
             oauth2UserDTO = OAuth2UserDTO.from(member);
-            // 로그인하지 않은 사용자
-        } else {
+
+        }
+        // 로그인하지 않은 사용자
+        else {
             // authenticated() 를 거쳐야 하니까 ContextHolder 에 GUEST 로 집어넣음
             oauth2UserDTO = OAuth2UserDTO.from(null);
         }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtAuthFilter.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtAuthFilter.java
@@ -4,19 +4,24 @@ package com.ywoosang.tech.domain.auth.jwt;
 import com.ywoosang.tech.domain.auth.oauth2.dto.CustomOAuth2User;
 import com.ywoosang.tech.domain.auth.oauth2.dto.OAuth2UserDTO;
 import com.ywoosang.tech.domains.member.entity.Member;
+import com.ywoosang.tech.exception.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
@@ -28,14 +33,15 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String accessToken = jwtService.resolveToken(request);
         OAuth2UserDTO oauth2UserDTO;
         // 로그인한 사용자
-        if(accessToken != null && !jwtService.isExpired(accessToken)) {
-            Member member = jwtService.getMemberFromToken(accessToken);
+        if(accessToken != null && !jwtService.isAccessTokenExpired(accessToken)) {
+            Member member = jwtService.getMemberFromAccessToken(accessToken);
             oauth2UserDTO = OAuth2UserDTO.from(member);
-        // 로그인하지 않은 사용자
+            // 로그인하지 않은 사용자
         } else {
             // authenticated() 를 거쳐야 하니까 ContextHolder 에 GUEST 로 집어넣음
             oauth2UserDTO = OAuth2UserDTO.from(null);
         }
+
         CustomOAuth2User customOAuth2User = new CustomOAuth2User(oauth2UserDTO);
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 customOAuth2User,

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtService.java
@@ -1,10 +1,9 @@
 package com.ywoosang.tech.domain.auth.jwt;
 
 import com.ywoosang.tech.code.AuthErrorCode;
-import com.ywoosang.tech.domain.auth.service.RedisService;
+import com.ywoosang.tech.domain.auth.service.RedisAuthService;
 import com.ywoosang.tech.domains.member.entity.Member;
 import com.ywoosang.tech.domains.member.repository.MemberRepository;
-import com.ywoosang.tech.enums.MemberRole;
 import com.ywoosang.tech.exception.CustomException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -19,14 +18,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
-import java.security.Key;
 import java.util.Date;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtService {
-    private final RedisService redisService;
+    private final RedisAuthService redisService;
     MemberRepository memberRepository;
 
     @Value("${jwt.access.secret}")
@@ -49,39 +47,28 @@ public class JwtService {
 
     @PostConstruct
     public void initialize() {
-        System.out.println("accessTokenSecret = " + accessTokenSecret);
-        System.out.println("refreshTokenSecret = " + refreshTokenSecret);
-
         accessTokenSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(accessTokenSecret));
         refreshTokenSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(refreshTokenSecret));
     }
 
+
+    // Authorization 헤더로부터 토큰을 가져온다.
     public String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)){
             return bearerToken.substring(BEARER_PREFIX.length());
         }
+        // 에러 처리 추가 요망
         return null;
     }
 
-    public String createAccessToken(String email) {
-        return Jwts.builder()
-                .claim("email", email)
-                .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + accessTokenExpiresIn))
-                .signWith(accessTokenSecretKey, Jwts.SIG.HS256)
-                .compact();
+    public String createAccessToken(Long memberId) {
+        return createToken(memberId, accessTokenExpiresIn, accessTokenSecretKey);
     }
 
-    public String createRefreshToken(String email) {
-        String refreshToken = Jwts.builder()
-                .claim("email", email)
-                .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiresIn))
-                .signWith(refreshTokenSecretKey, Jwts.SIG.HS256)
-                .compact();
-
-        String key = "refresh:" + email;
+    public String createRefreshToken(Long memberId) {
+        String refreshToken = createToken(memberId, refreshTokenExpiresIn, refreshTokenSecretKey);
+        String key = redisService.generateRefreshTokenKey(memberId);
         redisService.setValue(key, refreshToken, refreshTokenExpiresIn);
         return refreshToken;
     }
@@ -93,6 +80,29 @@ public class JwtService {
     public boolean isRefreshTokenExpired(String refreshToken) throws CustomException {
         return isTokenExpired(refreshToken, refreshTokenSecretKey);
     }
+
+    // 토큰에서 memberId 를 추출해 사용자를 가져온다.
+    public Member getMemberFromAccessToken(String token) {
+        Long memberId = getMemberIdFromAccessToken(token);
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.AUTHENTICATION_FAILED));
+    }
+
+    // 토큰의 만료여부 검사 후 만료되지 않았다면 호출할 것
+    public Long getMemberIdFromAccessToken(String token) {
+        return Jwts.parser().verifyWith(accessTokenSecretKey).build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("memberId",Long.class);
+    }
+
+    public Long getMemberIdFromRefreshToken(String token) {
+        return Jwts.parser().verifyWith(refreshTokenSecretKey).build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("memberId",Long.class);
+    }
+
 
     // 토큰 만료여부 검사
     private boolean isTokenExpired(String token, SecretKey secretKey) {
@@ -118,24 +128,14 @@ public class JwtService {
         }
     }
 
-    public Member getMemberFromAccessToken(String token) {
-        String email = getEmailFromAccessToken(token);
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new CustomException(AuthErrorCode.AUTHENTICATION_FAILED));
+    private String createToken(Long memberId, int expiresIn, SecretKey secretKey) {
+        return Jwts.builder()
+                .claim("memberId", memberId)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiresIn))
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
     }
 
-    // 토큰의 만료여부 검사 후 만료되지 않았다면 호출할 것
-    public String getEmailFromAccessToken(String token) {
-        return Jwts.parser().verifyWith(accessTokenSecretKey).build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .get("email",String.class);
-    }
 
-    public String getEmailFromRefreshToken(String token) {
-        return Jwts.parser().verifyWith(refreshTokenSecretKey).build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .get("email",String.class);
-    }
 }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtService.java
@@ -68,8 +68,7 @@ public class JwtService {
 
     public String createRefreshToken(Long memberId) {
         String refreshToken = createToken(memberId, refreshTokenExpiresIn, refreshTokenSecretKey);
-        String key = redisService.generateRefreshTokenKey(memberId);
-        redisService.setValue(key, refreshToken, refreshTokenExpiresIn);
+        redisService.setRefreshToken(memberId, refreshToken, refreshTokenExpiresIn);
         return refreshToken;
     }
 

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/jwt/JwtService.java
@@ -1,14 +1,15 @@
 package com.ywoosang.tech.domain.auth.jwt;
 
 import com.ywoosang.tech.code.AuthErrorCode;
+import com.ywoosang.tech.domain.auth.service.RedisService;
 import com.ywoosang.tech.domains.member.entity.Member;
 import com.ywoosang.tech.domains.member.repository.MemberRepository;
 import com.ywoosang.tech.enums.MemberRole;
 import com.ywoosang.tech.exception.CustomException;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -18,12 +19,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
+import java.security.Key;
 import java.util.Date;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtService {
+    private final RedisService redisService;
     MemberRepository memberRepository;
 
     @Value("${jwt.access.secret}")
@@ -36,7 +39,7 @@ public class JwtService {
     private String refreshTokenSecret;
 
     @Value("${jwt.refresh.expires-in}")
-    private int refreshExpiresIn;
+    private int refreshTokenExpiresIn;
 
     private SecretKey accessTokenSecretKey;
     private SecretKey refreshTokenSecretKey;
@@ -61,10 +64,9 @@ public class JwtService {
         return null;
     }
 
-    public String createAccessToken(String email, MemberRole role) {
+    public String createAccessToken(String email) {
         return Jwts.builder()
                 .claim("email", email)
-                .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpiresIn))
                 .signWith(accessTokenSecretKey, Jwts.SIG.HS256)
@@ -72,33 +74,68 @@ public class JwtService {
     }
 
     public String createRefreshToken(String email) {
-        return null;
+        String refreshToken = Jwts.builder()
+                .claim("email", email)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiresIn))
+                .signWith(refreshTokenSecretKey, Jwts.SIG.HS256)
+                .compact();
+
+        String key = "refresh:" + email;
+        redisService.setValue(key, refreshToken, refreshTokenExpiresIn);
+        return refreshToken;
     }
 
+    public boolean isAccessTokenExpired(String accessToken) throws CustomException {
+        return isTokenExpired(accessToken, accessTokenSecretKey);
+    }
 
-    public boolean isExpired(String token) {
+    public boolean isRefreshTokenExpired(String refreshToken) throws CustomException {
+        return isTokenExpired(refreshToken, refreshTokenSecretKey);
+    }
+
+    // 토큰 만료여부 검사
+    private boolean isTokenExpired(String token, SecretKey secretKey) {
+        // setSigningKey 가 Deprecated 되면서 verifyWith 를 사용
+        // 공식문서 https://javadoc.io/doc/io.jsonwebtoken/jjwt-api/0.12.3/io/jsonwebtoken/JwtParserBuilder.html
         try {
-            return Jwts.parser().verifyWith(accessTokenSecretKey).build()
+            return Jwts.parser().verifyWith(secretKey).build()
                     .parseSignedClaims(token)
                     .getPayload()
                     .getExpiration()
                     .before(new Date());
         } catch (JwtException e) {
-            log.warn("Invalid JWT token: {}", e.getMessage());
+            if (e instanceof MalformedJwtException) {
+                log.warn("올바르지 않은 형식의 JWT 토큰: {}", e.getMessage());
+            } else if (e instanceof SignatureException) {
+                log.warn("JWT 서명이 일치하지 않음: {}", e.getMessage());
+            } else if (e instanceof UnsupportedJwtException) {
+                log.warn("토큰의 특정 헤더나 클레임이 지원되지 않음: {}", e.getMessage());
+            } else {
+                log.warn("JWT 만료기간 검사 처리 중 오류 발생: {}", e.getMessage());
+            }
             throw new CustomException(AuthErrorCode.AUTHENTICATION_FAILED);
         }
     }
 
-    public Member getMemberFromToken(String token) {
-        String email = getEmailFromToken(token);
+    public Member getMemberFromAccessToken(String token) {
+        String email = getEmailFromAccessToken(token);
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTHENTICATION_FAILED));
     }
 
-    private String getEmailFromToken(String token) {
+    // 토큰의 만료여부 검사 후 만료되지 않았다면 호출할 것
+    public String getEmailFromAccessToken(String token) {
         return Jwts.parser().verifyWith(accessTokenSecretKey).build()
                 .parseSignedClaims(token)
                 .getPayload()
-                .get("role",String.class);
+                .get("email",String.class);
+    }
+
+    public String getEmailFromRefreshToken(String token) {
+        return Jwts.parser().verifyWith(refreshTokenSecretKey).build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("email",String.class);
     }
 }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/CustomSuccessHandler.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/CustomSuccessHandler.java
@@ -3,11 +3,8 @@ package com.ywoosang.tech.domain.auth.oauth2;
 import com.ywoosang.tech.domain.auth.oauth2.dto.CustomOAuth2User;
 import com.ywoosang.tech.domain.auth.jwt.JwtService;
 import com.ywoosang.tech.domain.auth.oauth2.utils.CookieUtil;
-import com.ywoosang.tech.enums.MemberRole;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,12 +26,15 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
-        String email = customUserDetails.getEmail();
+        Long memberId = customUserDetails.getMemberId();
         // jwt 생성
-        String accessToken = jwtService.createAccessToken(email);
-        String refreshToken = jwtService.createRefreshToken(email);
+        String accessToken = jwtService.createAccessToken(memberId);
+        String refreshToken = jwtService.createRefreshToken(memberId);
 
+        // 쿠키에 추가
         response.addCookie(cookieUtil.createAccessTokenCookie(accessToken));
+        response.addCookie(cookieUtil.createRefreshTokenCookie(refreshToken));
+        // 프론트엔드로 리다이렉트
         response.sendRedirect(authRedirectUrl);
     }
 }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/CustomSuccessHandler.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/CustomSuccessHandler.java
@@ -29,11 +29,11 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
-        String email = customUserDetails.getName();
-        MemberRole role = customUserDetails.getRole();
+        String email = customUserDetails.getEmail();
         // jwt 생성
-        String accessToken = jwtService.createAccessToken(email, role);
-        // String refreshToken = jwtService.createRefreshToken(email);
+        String accessToken = jwtService.createAccessToken(email);
+        String refreshToken = jwtService.createRefreshToken(email);
+
         response.addCookie(cookieUtil.createAccessTokenCookie(accessToken));
         response.sendRedirect(authRedirectUrl);
     }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/CustomOAuth2User.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/CustomOAuth2User.java
@@ -4,7 +4,6 @@ import com.ywoosang.tech.enums.MemberRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -20,11 +19,7 @@ public class CustomOAuth2User implements OAuth2User {
 
     @Override
     public Map<String, Object> getAttributes() {
-        return Map.of(
-                "email", oauth2UserDTO.getEmail(),
-                "nickname", oauth2UserDTO.getNickname(),
-                "profileImage", oauth2UserDTO.getProfileImage()
-        );
+        return Map.of("userId", oauth2UserDTO.getMemberId(), "email", oauth2UserDTO.getEmail(), "nickname", oauth2UserDTO.getNickname(), "profileImage", oauth2UserDTO.getProfileImage());
     }
 
     @Override
@@ -40,6 +35,10 @@ public class CustomOAuth2User implements OAuth2User {
     }
 
     // getAttribute 로 가져올 수 있지만 명시적으로 가져오기 위해 추가
+    public Long getMemberId() {
+        return oauth2UserDTO.getMemberId();
+    }
+
     public MemberRole getRole() {
         return oauth2UserDTO.getRole();
     }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/OAuth2UserDTO.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/dto/OAuth2UserDTO.java
@@ -7,13 +7,15 @@ import lombok.Getter;
 
 @Getter
 public class OAuth2UserDTO {
+    private final Long memberId;
     private final String nickname;
     private final String email;
     private final String profileImage;
     private final MemberRole role;
 
     @Builder
-    private OAuth2UserDTO(String nickname, String email, String profileImage, MemberRole role) {
+    private OAuth2UserDTO(Long memberId, String nickname, String email, String profileImage, MemberRole role) {
+        this.memberId = memberId;
         this.nickname = nickname;
         this.email = email;
         this.profileImage = profileImage;
@@ -27,6 +29,7 @@ public class OAuth2UserDTO {
                     .build();
         }
         return OAuth2UserDTO.builder()
+                .memberId(member.getMemberId())
                 .nickname(member.getNickname())
                 .email(member.getEmail())
                 .profileImage(member.getProfileImage())

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/service/CustomOAuth2UserService.java
@@ -46,11 +46,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                             .profileImage(oAuth2Attributes.getProfileImage())
                             .role(MemberRole.USER)
                             .build();
-
                     log.info("사용자 가입 이메일: {}", newMember.getEmail());
                     return memberRepository.save(newMember);
                 });
-        log.info("사용자 로그인 이메일: {}", member.getEmail());
+        log.info("사용자 로그인 이메일: {} 사용자 로그인 아이디: {}", member.getEmail(), member.getMemberId());
         OAuth2UserDTO oauth2UserDTO = OAuth2UserDTO.from(member);
 
         // SecurityContext 에 저장

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/utils/CookieUtil.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/utils/CookieUtil.java
@@ -1,6 +1,5 @@
 package com.ywoosang.tech.domain.auth.oauth2.utils;
 
-
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +12,12 @@ public class CookieUtil {
 
     @Value("${cookie.domain}")
     private String domain;
+
+    @Value("${cookie.access-name}")
+    private String accessTokenName;
+
+    @Value("${cookie.refresh-name}")
+    private String refreshTokenName;
 
     // 로그인 직후 로컬스토리지로 이동시키기 때문에 만료시간을 짧게 설정
     public Cookie createTokenCookie(String cookieName, String token) {
@@ -36,15 +41,15 @@ public class CookieUtil {
     }
 
     public Cookie createAccessTokenCookie(String token) {
-        return createTokenCookie("accessToken", token);
+        return createTokenCookie(accessTokenName, token);
     }
 
     public Cookie createRefreshTokenCookie(String token) {
-        return createTokenCookie("refreshToken", token);
+        return createTokenCookie(refreshTokenName, token);
     }
 
     public void clearAccessAndRefreshTokenCookie(HttpServletResponse response) {
-        clearTokenCookie("accessToken", response);
-        clearTokenCookie("refreshToken", response);
+        clearTokenCookie(accessTokenName, response);
+        clearTokenCookie(refreshTokenName, response);
     }
 }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/utils/CookieUtil.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/oauth2/utils/CookieUtil.java
@@ -19,27 +19,6 @@ public class CookieUtil {
     @Value("${cookie.refresh-name}")
     private String refreshTokenName;
 
-    // 로그인 직후 로컬스토리지로 이동시키기 때문에 만료시간을 짧게 설정
-    public Cookie createTokenCookie(String cookieName, String token) {
-        Cookie cookie = new Cookie(cookieName, token);
-        cookie.setMaxAge(maxAge);
-        cookie.setPath("/");
-        cookie.setDomain(domain);
-        cookie.setHttpOnly(false);
-        cookie.setSecure(false);
-        return cookie;
-    }
-
-    public void clearTokenCookie(String cookieName, HttpServletResponse response) {
-        Cookie cookie = new Cookie(cookieName, null);
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
-        cookie.setDomain(domain);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(false);
-        response.addCookie(cookie);
-    }
-
     public Cookie createAccessTokenCookie(String token) {
         return createTokenCookie(accessTokenName, token);
     }
@@ -52,4 +31,26 @@ public class CookieUtil {
         clearTokenCookie(accessTokenName, response);
         clearTokenCookie(refreshTokenName, response);
     }
+
+    // 로그인 직후 로컬스토리지로 이동시키기 때문에 만료시간을 짧게 설정
+    private Cookie createTokenCookie(String cookieName, String token) {
+        Cookie cookie = new Cookie(cookieName, token);
+        cookie.setMaxAge(maxAge);
+        cookie.setPath("/");
+        cookie.setDomain(domain);
+        cookie.setHttpOnly(false);
+        cookie.setSecure(false);
+        return cookie;
+    }
+
+    private void clearTokenCookie(String cookieName, HttpServletResponse response) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setDomain(domain);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        response.addCookie(cookie);
+    }
+
 }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/AuthService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/AuthService.java
@@ -1,10 +1,8 @@
 package com.ywoosang.tech.domain.auth.service;
 
 import com.ywoosang.tech.code.AuthErrorCode;
-import com.ywoosang.tech.code.ErrorCode;
 import com.ywoosang.tech.domain.auth.dto.TokenResponse;
 import com.ywoosang.tech.domain.auth.jwt.JwtService;
-import com.ywoosang.tech.domains.member.entity.Member;
 import com.ywoosang.tech.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,24 +12,26 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    private final RedisService redisService;
+    private final RedisAuthService redisService;
     private JwtService jwtService;
 
     public TokenResponse reissueToken(String refreshToken) {
-        log.info("refreshToken 재발급: {}", refreshToken);
+        log.info("refreshToken 을 이용해 accessToken 재발급: {}", refreshToken);
+
+        // refresh 토큰 만료여부 검사
         if (jwtService.isRefreshTokenExpired(refreshToken)) {
             log.info("refreshToken 만료: {}", refreshToken);
             throw new CustomException(AuthErrorCode.TOKEN_EXPIRED);
         }
-        String email = jwtService.getEmailFromRefreshToken(refreshToken);
-        String redisKey = "refresh:" + email;
+        Long memberId = jwtService.getMemberIdFromRefreshToken(refreshToken);
+        String redisKey = redisService.generateRefreshTokenKey(memberId);
         String redisRefreshToken = redisService.getValue(redisKey);
-        // 유효한 jwt 토큰이라면, 사용자의 refreshToken 과 대조해
+        // 유효한 jwt 토큰이라면, 사용자의 refreshToken 과 대조한다.
         if (redisRefreshToken == null || !redisRefreshToken.equals(refreshToken)) {
             log.warn("사용자의 refreshToken 이 아님: {}", refreshToken);
             throw new CustomException(AuthErrorCode.ACCESS_DENIED);
         }
-        String newAccessToken = jwtService.createAccessToken(email);
+        String newAccessToken = jwtService.createAccessToken(memberId);
         return TokenResponse.builder().accessToken(newAccessToken).build();
     }
 }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/AuthService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/AuthService.java
@@ -1,0 +1,37 @@
+package com.ywoosang.tech.domain.auth.service;
+
+import com.ywoosang.tech.code.AuthErrorCode;
+import com.ywoosang.tech.code.ErrorCode;
+import com.ywoosang.tech.domain.auth.dto.TokenResponse;
+import com.ywoosang.tech.domain.auth.jwt.JwtService;
+import com.ywoosang.tech.domains.member.entity.Member;
+import com.ywoosang.tech.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final RedisService redisService;
+    private JwtService jwtService;
+
+    public TokenResponse reissueToken(String refreshToken) {
+        log.info("refreshToken 재발급: {}", refreshToken);
+        if (jwtService.isRefreshTokenExpired(refreshToken)) {
+            log.info("refreshToken 만료: {}", refreshToken);
+            throw new CustomException(AuthErrorCode.TOKEN_EXPIRED);
+        }
+        String email = jwtService.getEmailFromRefreshToken(refreshToken);
+        String redisKey = "refresh:" + email;
+        String redisRefreshToken = redisService.getValue(redisKey);
+        // 유효한 jwt 토큰이라면, 사용자의 refreshToken 과 대조해
+        if (redisRefreshToken == null || !redisRefreshToken.equals(refreshToken)) {
+            log.warn("사용자의 refreshToken 이 아님: {}", refreshToken);
+            throw new CustomException(AuthErrorCode.ACCESS_DENIED);
+        }
+        String newAccessToken = jwtService.createAccessToken(email);
+        return TokenResponse.builder().accessToken(newAccessToken).build();
+    }
+}

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/AuthService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/AuthService.java
@@ -17,15 +17,13 @@ public class AuthService {
 
     public TokenResponse reissueToken(String refreshToken) {
         log.info("refreshToken 을 이용해 accessToken 재발급: {}", refreshToken);
-
         // refresh 토큰 만료여부 검사
         if (jwtService.isRefreshTokenExpired(refreshToken)) {
             log.info("refreshToken 만료: {}", refreshToken);
             throw new CustomException(AuthErrorCode.TOKEN_EXPIRED);
         }
         Long memberId = jwtService.getMemberIdFromRefreshToken(refreshToken);
-        String redisKey = redisService.generateRefreshTokenKey(memberId);
-        String redisRefreshToken = redisService.getValue(redisKey);
+        String redisRefreshToken = redisService.getRefreshToken(memberId);
         // 유효한 jwt 토큰이라면, 사용자의 refreshToken 과 대조한다.
         if (redisRefreshToken == null || !redisRefreshToken.equals(refreshToken)) {
             log.warn("사용자의 refreshToken 이 아님: {}", refreshToken);

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/RedisAuthService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/RedisAuthService.java
@@ -13,17 +13,20 @@ import java.time.Duration;
 public class RedisAuthService {
     private final StringRedisTemplate redisTemplate;
 
-    public void setValue(String key, String value, int expiresIn) {
+    public void setRefreshToken(Long memberId , String value, int expiresIn) {
         ValueOperations<String, String> valueOps = redisTemplate.opsForValue();
+        String key = generateRefreshTokenKey(memberId);
         valueOps.set(key, value, Duration.ofSeconds(expiresIn));
     }
 
-    public String getValue(String key) {
+    public String getRefreshToken(Long memberId) {
         ValueOperations<String, String> valueOps = redisTemplate.opsForValue();
+        String key = generateRefreshTokenKey(memberId);
         return valueOps.get(key);
     }
 
-    public void deleteValue(String key) {
+    public void deleteValue(Long memberId) {
+        String key = generateRefreshTokenKey(memberId);
         redisTemplate.delete(key);
     }
 

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/RedisAuthService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/RedisAuthService.java
@@ -4,14 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
-
 import java.time.Duration;
 
 // 공식문서 StringRedisTemplate
 // https://docs.spring.io/spring-data/redis/docs/current/api/org/springframework/data/redis/core/StringRedisTemplate.html
 @Component
 @RequiredArgsConstructor
-public class RedisService {
+public class RedisAuthService {
     private final StringRedisTemplate redisTemplate;
 
     public void setValue(String key, String value, int expiresIn) {
@@ -23,7 +22,13 @@ public class RedisService {
         ValueOperations<String, String> valueOps = redisTemplate.opsForValue();
         return valueOps.get(key);
     }
+
     public void deleteValue(String key) {
         redisTemplate.delete(key);
+    }
+
+    // refreshToken 을 저장할 key 생성
+    public String generateRefreshTokenKey(Long memberId) {
+        return "auth:refresh:" + memberId;
     }
 }

--- a/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/RedisService.java
+++ b/blog-api/src/main/java/com/ywoosang/tech/domain/auth/service/RedisService.java
@@ -14,7 +14,7 @@ import java.time.Duration;
 public class RedisService {
     private final StringRedisTemplate redisTemplate;
 
-    public void setValue(String key, String value, Long expiresIn) {
+    public void setValue(String key, String value, int expiresIn) {
         ValueOperations<String, String> valueOps = redisTemplate.opsForValue();
         valueOps.set(key, value, Duration.ofSeconds(expiresIn));
     }

--- a/blog-api/src/test/java/com/ywoosang/tech/api/support/ControllerTestSetup.java
+++ b/blog-api/src/test/java/com/ywoosang/tech/api/support/ControllerTestSetup.java
@@ -2,6 +2,9 @@ package com.ywoosang.tech.api.support;
 
 
 import com.ywoosang.tech.controller.TestController;
+import com.ywoosang.tech.domain.auth.jwt.JwtService;
+import com.ywoosang.tech.domain.auth.service.AuthService;
+import com.ywoosang.tech.domain.auth.service.RedisAuthService;
 import com.ywoosang.tech.domains.post.repository.PostRepository;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 })
 public abstract class ControllerTestSetup {
 
+    // 객체를 JSON 형식으로 변환하기 위해
     @Autowired
     protected ObjectMapper objectMapper;
 
@@ -24,7 +28,17 @@ public abstract class ControllerTestSetup {
     protected MockMvc mockMvc;
 
     @MockBean
+    protected  RedisAuthService redisAuthService;
+
+    @MockBean
+    protected JwtService jwtService;
+
+    @MockBean
     protected PostRepository postRepository;
+
+    @MockBean
+    protected AuthService authService;
+
 
     // 테스트 객체를 JSON 형식으로 변환
     protected String toJson(Object dto) throws JsonProcessingException {

--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -16,7 +16,7 @@ services:
       - blog_network
 
   blog_redis:
-    image: redis:7.0.5
+    image: redis:7
     container_name: blog_redis
     ports:
       - "6379:6379"


### PR DESCRIPTION
### 상세내용
- refreshToken 발급 로직 추가
- redis 접속 환경변수 수정
- redis 키를 생성할 때 이메일 대신 사용자 아이디를 사용하도록 리팩토링
- RedisService를 인증용 RedisAuthService로 변경
- 인증 관련 서비스, 컨트롤러에 accessToken 갱신 로직 추가
- 컨트롤러 테스트에 인증 관련 Bean 모킹 추가
- CI 시 redis 연결을 위해 yml 수정